### PR TITLE
Significantly increase connection_timeout

### DIFF
--- a/PHPToolkit/NSPHPClient.php
+++ b/PHPToolkit/NSPHPClient.php
@@ -227,7 +227,7 @@ class NSPHPClient {
 
         $options['classmap'] = $this->classmap;
         $options['trace'] = 1;
-        $options['connection_timeout'] = 5;
+        $options['connection_timeout'] = 3600;
         $options['cache_wsdl'] = WSDL_CACHE_BOTH;
         $httpheaders = "PHP-SOAP/" . phpversion() . " + NetSuite PHP Toolkit " . $this->nsversion;
 


### PR DESCRIPTION
Increasing this timeout appears to resolve an issue encountered intermittently when large requests are sent to NetSuite and the SOAP client is "unable to fetch http headers" in the response.
